### PR TITLE
Fix navigation from buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gude-foods",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gude-foods",
-      "version": "3.1.5",
+      "version": "3.1.6",
       "dependencies": {
         "@emailjs/browser": "^3.6.2",
         "@emotion/react": "^11.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gude-foods",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "private": true,
   "homepage": "https://www.gudefoods.com",
   "dependencies": {

--- a/src/Components/Cookbook.js
+++ b/src/Components/Cookbook.js
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
@@ -29,6 +29,8 @@ function Cookbook(props) {
     filteringOptions = {},
     setFilteringOptions,
   } = props;
+
+  let navigate = useNavigate();
 
   const [advancedFiltersTooltipOpen, setAdvancedFiltersTooltipOpen] =
     useState(false);
@@ -158,12 +160,13 @@ function Cookbook(props) {
                         variant="outlined"
                         size="large"
                         sx={{ flex: 1 }}
+                        onClick={() => {
+                          navigate(`/recipe/${recipeId}`);
+                        }}
                       >
-                        <Link to={`/recipe/${recipeId}/`}>
-                          <Typography color="secondary">
-                            View full recipe
-                          </Typography>
-                        </Link>
+                        <Typography color="secondary">
+                          View full recipe
+                        </Typography>
                       </Button>
                       <Button
                         color="secondary"
@@ -243,10 +246,14 @@ function Cookbook(props) {
       </Typography>
       <Stack sx={{ paddingTop: "15px" }} spacing={3} alignItems="center">
         {renderSearchAndFilters()}
-        <Button color="primary" variant="contained">
-          <Link to={`/recipe/create`}>
-            <Typography color="primary.contrastText">Add new recipe</Typography>
-          </Link>
+        <Button
+          color="primary"
+          variant="contained"
+          onClick={() => {
+            navigate(`/recipe/create`);
+          }}
+        >
+          <Typography color="primary.contrastText">Add new recipe</Typography>
         </Button>
         {renderRecipeStack()}
       </Stack>

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
@@ -10,10 +10,11 @@ import Button from "@mui/material/Button";
 
 function Home(props) {
   const { glossary, basicFoodTagAssociation, shoppingList, cookbook } = props;
+  let navigate = useNavigate();
 
   const renderRecipeCard = () => {
     let messageContent = null;
-    let buttonContent = null;
+    let renderedButton = null;
 
     if (!cookbook) {
       messageContent = (
@@ -22,10 +23,16 @@ function Home(props) {
         </Typography>
       );
 
-      buttonContent = (
-        <Link to={`/recipe/create`}>
+      renderedButton = (
+        <Button
+          color="secondary"
+          variant="outlined"
+          onClick={() => {
+            navigate(`/recipe/create`);
+          }}
+        >
           <Typography color="secondary">Create a recipe</Typography>
-        </Link>
+        </Button>
       );
     } else {
       const recipeList = Object.keys(cookbook);
@@ -59,10 +66,16 @@ function Home(props) {
         </>
       );
 
-      buttonContent = (
-        <Link to={`/recipe/${recipeId}`}>
+      renderedButton = (
+        <Button
+          color="secondary"
+          variant="outlined"
+          onClick={() => {
+            navigate(`/recipe/${recipeId}`);
+          }}
+        >
           <Typography color="secondary">Go to recipe</Typography>
-        </Link>
+        </Button>
       );
     }
 
@@ -76,9 +89,7 @@ function Home(props) {
             {messageContent}
           </CardContent>
           <CardActions sx={{ justifyContent: "flex-end" }}>
-            <Button color="secondary" variant="outlined">
-              {buttonContent}
-            </Button>
+            {renderedButton}
           </CardActions>
         </Card>
       </Box>
@@ -111,10 +122,14 @@ function Home(props) {
             </Typography>
           </CardContent>
           <CardActions sx={{ justifyContent: "flex-end" }}>
-            <Button color="secondary" variant="outlined">
-              <Link to={`/glossary`}>
-                <Typography color="secondary">Go to Glossary</Typography>
-              </Link>
+            <Button
+              color="secondary"
+              variant="outlined"
+              onClick={() => {
+                navigate(`/glossary`);
+              }}
+            >
+              <Typography color="secondary">Go to Glossary</Typography>
             </Button>
           </CardActions>
         </Card>
@@ -166,10 +181,14 @@ function Home(props) {
             {messageContent}
           </CardContent>
           <CardActions sx={{ justifyContent: "flex-end" }}>
-            <Button color="secondary" variant="outlined">
-              <Link to={`/shoppingList`}>
-                <Typography color="secondary">Go to Shopping List</Typography>
-              </Link>
+            <Button
+              color="secondary"
+              variant="outlined"
+              onClick={() => {
+                navigate(`/shoppingList`);
+              }}
+            >
+              <Typography color="secondary">Go to Shopping List</Typography>
             </Button>
           </CardActions>
         </Card>
@@ -196,10 +215,14 @@ function Home(props) {
             </Typography>
           </CardContent>
           <CardActions sx={{ justifyContent: "flex-end" }}>
-            <Button color="secondary" variant="outlined">
-              <Link to={`/cookbook`}>
-                <Typography color="secondary">Go to Cookbook</Typography>
-              </Link>
+            <Button
+              color="secondary"
+              variant="outlined"
+              onClick={() => {
+                navigate(`/cookbook`);
+              }}
+            >
+              <Typography color="secondary">Go to Cookbook</Typography>
             </Button>
           </CardActions>
         </Card>

--- a/src/Components/NavBar.js
+++ b/src/Components/NavBar.js
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 import AppBar from "@mui/material/AppBar";
 import Box from "@mui/material/Box";
@@ -26,6 +26,7 @@ const pages = ["cookbook", "shoppingList", "glossary", "settings"];
 
 const NavBar = (props) => {
   const { addAlert } = props;
+  let navigate = useNavigate();
 
   const [anchorElNav, setAnchorElNav] = useState(null);
 
@@ -95,12 +96,16 @@ const NavBar = (props) => {
             >
               {pages
                 .map((page) => (
-                  <MenuItem key={page} onClick={handleCloseNavMenu}>
-                    <Link to={`/${page}`}>
-                      <Typography textAlign="center">
-                        {presentationNames[page]}
-                      </Typography>
-                    </Link>
+                  <MenuItem
+                    key={page}
+                    onClick={() => {
+                      handleCloseNavMenu();
+                      navigate(`/${page}`);
+                    }}
+                  >
+                    <Typography textAlign="center">
+                      {presentationNames[page]}
+                    </Typography>
                   </MenuItem>
                 ))
                 .concat(
@@ -135,12 +140,13 @@ const NavBar = (props) => {
             {pages.map((page) => (
               <Button
                 key={page}
-                onClick={handleCloseNavMenu}
+                onClick={() => {
+                  handleCloseNavMenu();
+                  navigate(`/${page}`);
+                }}
                 sx={{ my: 2, color: "white", display: "block" }}
               >
-                <Link to={`/${page}`}>
-                  <Typography>{presentationNames[page]}</Typography>
-                </Link>
+                <Typography>{presentationNames[page]}</Typography>
               </Button>
             ))}
           </Box>

--- a/src/Components/Recipe.js
+++ b/src/Components/Recipe.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useParams, useNavigate, Link } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 
 import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
@@ -281,20 +281,21 @@ function Recipe(props) {
           variant="outlined"
           size="small"
           sx={{ ...(isCreating ? {} : { height: "50px" }), flexGrow: "1" }}
+          onClick={() => {
+            navigate(`/cookbook`);
+          }}
         >
-          <Link to={`/cookbook`}>
-            <Typography color="secondary">
-              {isCreating ? (
-                "Back to cookbook"
-              ) : (
-                <>
-                  <span>Back to</span>
-                  <br />
-                  <span>cookbook</span>
-                </>
-              )}
-            </Typography>
-          </Link>
+          <Typography color="secondary">
+            {isCreating ? (
+              "Back to cookbook"
+            ) : (
+              <>
+                <span>Back to</span>
+                <br />
+                <span>cookbook</span>
+              </>
+            )}
+          </Typography>
         </Button>
       )}
 

--- a/src/Components/Settings.js
+++ b/src/Components/Settings.js
@@ -117,7 +117,7 @@ function Settings(props) {
                 rel="noopener"
                 color="secondary"
               >
-                here{" "}
+                {"here "}
                 <OpenInNewIcon
                   fontSize="inherit"
                   sx={{ verticalAlign: "sub" }}


### PR DESCRIPTION
Fixed bug where clicking a button wouldn't navigate to the location. This was because it was actually the text in the button being a link could only navigate, and clicking anywhere else in the button doesn't interact with the link. The fix is to use the `useNavigate` hook in the buttons' onClick handler